### PR TITLE
Update `TemplateResponse` calls to `Starlette 1.x` API

### DIFF
--- a/pypi_browser/app.py
+++ b/pypi_browser/app.py
@@ -118,7 +118,7 @@ templates.env.globals['pypi_browser_version'] = importlib.metadata.version('pypi
 
 
 async def home(request: Request) -> Response:
-    return templates.TemplateResponse('home.html', {'request': request})
+    return templates.TemplateResponse(request, 'home.html')
 
 
 async def package(request: Request) -> Response:
@@ -150,9 +150,9 @@ async def package(request: Request) -> Response:
             reverse=True,
         )
         return templates.TemplateResponse(
+            request,
             'package.html',
             {
-                'request': request,
                 'package': package_name,
                 'version_to_files': version_to_files_sorted,
                 'total_files': len(set(itertools.chain.from_iterable(version_to_files.values()))),
@@ -219,9 +219,9 @@ async def package_file(request: Request) -> Response:
         metadata = {}
 
     return templates.TemplateResponse(
+        request,
         'package_file.html',
         {
-            'request': request,
             'package': package_name,
             'package_is_tarball': package.package_format is PackageFormat.TARBALL,
             'filename': file_name,
@@ -336,9 +336,9 @@ async def package_file_archive_path(request: Request) -> Response:
                 lexer = pygments.lexers.special.TextLexer(stripnl=False)
 
             return templates.TemplateResponse(
+                request,
                 'package_file_archive_path.html',
                 {
-                    'request': request,
                     'package': package_name,
                     'package_is_tarball': package.package_format is PackageFormat.TARBALL,
                     'filename': file_name,
@@ -359,9 +359,9 @@ async def package_file_archive_path(request: Request) -> Response:
         else:
             # Case 2: too long to syntax highlight.
             return templates.TemplateResponse(
+                request,
                 'package_file_archive_path.html',
                 {
-                    'request': request,
                     'package': package_name,
                     'package_is_tarball': package.package_format is PackageFormat.TARBALL,
                     'filename': file_name,
@@ -373,9 +373,9 @@ async def package_file_archive_path(request: Request) -> Response:
 
     # Case 3: link to binary
     return templates.TemplateResponse(
+        request,
         'package_file_archive_path.html',
         {
-            'request': request,
             'package': package_name,
             'package_is_tarball': package.package_format is PackageFormat.TARBALL,
             'filename': file_name,


### PR DESCRIPTION

  ## Problem                                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  Starlette [1.0](https://starlette.dev/release-notes/#100-march-22-2026) removed the deprecated `TemplateResponse(name, context)` signature. The new signature — introduced in [0.29.0](https://www.starlette.io/release-notes/#0290-july-13-2023) — takes `request` as the first positional argument. The old style emitted deprecation warnings since 0.29.0 and is fully removed in 1.x.     
                                                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  ## Solution                                                                                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  Update all `TemplateResponse` calls in `app.py` to use the new signature:                                                                                                                                                                                                                                                                                                                                                               
   
  ```python                                                                                                                                                                                                                                                                                                                                                                                                                               
  # Before                                                  
  templates.TemplateResponse('template.html', {'request': request, ...})                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  # After                                                                                                                                                                                                                                                                                                                                                                                                                                 
  templates.TemplateResponse(request, 'template.html', {...})
```                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  The new signature has been supported since at least Starlette [0.29.0](https://starlette.dev/release-notes/#0290-july-13-2023), so this change is backwards-compatible with older installs while also working correctly on 1.x.                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  ## Verification                                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  Verified by importing the app against Starlette 0.40.0, 0.46.0, and 1.0.0 with -W error::DeprecationWarning — no warnings or errors in any case.